### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![License](https://img.shields.io/badge/apache-2.0-orange.svg)](LICENSE)
 [ ![Download](https://api.bintray.com/packages/7heaven/maven/SHSegmentControl/images/download.svg) ](https://bintray.com/7heaven/maven/SHSegmentControl/_latestVersion)
 
-###中文
+### 中文
 
-#a simple SegmentControl Widget
+# a simple SegmentControl Widget
 
 ![art2](arts/arts2.gif)
 
@@ -67,9 +67,9 @@ mSegmentHorzontal.setOnSegmentControlClickListener(new SegmentControl.OnSegmentC
 });
 ```
 
-###English
+### English
 
-#a simple SegmentControl Widget
+# a simple SegmentControl Widget
 
 ![art2](arts/arts2.gif)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
