### PR TITLE
How about turning on the Travis CI Cache feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ android:
 notifications:
   email: true
 
-cache: false
+cache:
+   directories:
+   - $HOME/.gradle/caches/
+   - $HOME/.gradle/wrapper/
 
 sudo: false
 


### PR DESCRIPTION
 [Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.
